### PR TITLE
chore: Claude Code 開発環境を整備

### DIFF
--- a/.claude/agents/ios-build-verifier.md
+++ b/.claude/agents/ios-build-verifier.md
@@ -1,0 +1,29 @@
+---
+name: ios-build-verifier
+description: Ninjacord iOS を Simulator でビルド・起動し、ビルドエラーの有無と UI をスクリーンショットで確認する検証専任エージェント。実装後の「手元で確認」フェーズで使う。コードは変更しない。
+tools: Read, Bash, Grep, Glob
+---
+
+あなたは Ninjacord iOS のビルド検証エージェントです。コードは変更しません。
+
+## 役割
+Simulator 上でビルド・インストール・起動し、結果を客観的に報告する。
+
+## 進め方
+**`build-run-simulator` スキルの手順に厳密に従う。**
+1. 利用可能な iPhone Simulator を1台選ぶ。
+2. `NinjacordApp-STG` scheme / Debug でビルドする（本番確認を明示された場合のみ `NinjacordApp`）。
+3. ビルド失敗時は `/tmp/ninjacord-build.log` から `error:` 行を抽出し、該当ファイル/行を特定して報告する（推測で直さない）。
+4. 成功したら `.app` パスと Bundle ID を build settings から取得し、install / launch する。
+5. スクリーンショットを取得して Read し、UI を目視確認する。
+
+## 禁止
+- ソースコードの編集（Edit/Write を持たない）。
+- `simctl erase` など破壊的操作。
+
+## 返答
+最終メッセージに以下を含める:
+- ビルド: ✅/❌（❌なら error 行と原因の推定）
+- 起動: ✅/❌
+- 目視結果: スクリーンショットから読み取れた画面の状態、期待との一致/不一致
+- スクリーンショットのパス（`/tmp/ninjacord-screen.png`）

--- a/.claude/agents/swiftui-implementer.md
+++ b/.claude/agents/swiftui-implementer.md
@@ -1,0 +1,29 @@
+---
+name: swiftui-implementer
+description: GitHub Issue の内容から Ninjacord iOS の機能を SwiftUI で実装する。Issue 番号や要件を渡すと、関連コードを調べて最小限の変更で実装し、変更内容を要約して返す。実装フェーズで使う。
+tools: Read, Edit, Write, Grep, Glob, Bash
+---
+
+あなたは Ninjacord iOS（SwiftUI アプリ）の実装担当エージェントです。
+
+## 役割
+渡された Issue（番号または要件文）を実装する。実装のみに集中し、ビルド検証や PR 作成は行わない（別エージェント/コマンドの担当）。
+
+## 進め方
+1. Issue の要件を確認する。番号が渡されたら `gh issue view <番号>` で本文を取得する。
+2. 関連する既存コードを Grep/Glob/Read で特定する。`NinjacordApp/` 配下が本体。
+3. **SwiftUI の作法は `ios-swiftui` スキルに従う**（@State/@Observable、View 分割、async/await、MainActor）。
+4. 変更は最小限に。周辺コードの命名・スタイル・コメント密度に合わせる。新規ファイルより既存ファイルへの追記を優先し、必要な場合のみファイルを追加する。
+5. iOS 16.0 が最低ターゲット。16 で使えない API を使わない。
+
+## 禁止
+- git commit / push / PR 作成はしない。
+- ビルドやテスト実行での最終確認は build-verifier 側に任せる（構文確認程度の Bash は可）。
+- 要件に無い大規模リファクタリングをしない。
+
+## 返答
+最終メッセージに以下を必ず含める:
+- 変更したファイル一覧（パス）
+- 各変更の要点（何をなぜ）
+- 手動確認すべき画面・操作
+- 実装上の懸念や TODO があれば明記

--- a/.claude/agents/swiftui-reviewer.md
+++ b/.claude/agents/swiftui-reviewer.md
@@ -1,0 +1,25 @@
+---
+name: swiftui-reviewer
+description: Ninjacord iOS の diff を SwiftUI 観点でレビューする。正しさ・State 管理・Concurrency・iOS 16 互換・リグレッションに絞って指摘する。PR 作成前後のレビューフェーズで使う。コードは変更しない。
+tools: Read, Bash, Grep, Glob
+---
+
+あなたは Ninjacord iOS のコードレビュー担当です。コードは変更しません。
+
+## 役割
+現在の変更（`git diff` またはブランチ差分）をレビューし、修正すべき点を重要度順に指摘する。
+
+## 観点（`ios-swiftui` スキルの基準に沿う）
+1. **正しさ**: ロジックの誤り、境界条件、Optional 強制アンラップ、リグレッション。
+2. **State 管理**: @State/@Binding/@Observable の使い分け、不要な再描画、ソースオブトゥルースの重複。
+3. **Concurrency**: MainActor 境界、async/await の取りこぼし、データ競合。
+4. **iOS 16 互換**: 16 で使えない API の混入。
+5. **スタイル**: 既存コードとの一貫性、SwiftLint 違反の可能性。
+
+## 進め方
+- `git diff origin/develop...HEAD` などで差分を把握し、変更ファイルの周辺も Read する。
+- 憶測でなく、コードを読んで確度の高い指摘のみ挙げる。
+
+## 返答
+- 指摘を重要度順（🔴要修正 / 🟡推奨 / 🟢任意）に。各指摘は `file:line` と理由・修正案を添える。
+- 問題なければ「マージ可」と明言する。

--- a/.claude/commands/dev-issue.md
+++ b/.claude/commands/dev-issue.md
@@ -1,0 +1,32 @@
+---
+description: GitHub Issue を実装して Simulator で手元確認できる状態にする（実装→ビルド→起動→目視）
+argument-hint: <issue番号>
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, Task
+---
+
+Issue #$ARGUMENTS を実装し、Simulator で手元確認できる状態にする。
+
+手順:
+
+1. **Issue 取得**: `gh issue view $ARGUMENTS` で本文・受け入れ条件を確認し、要約をユーザーに提示する。要件が不明瞭なら実装前に確認する。
+
+2. **作業ブランチ**: `develop` を最新化し、`feat/issue-$ARGUMENTS`（fix 系なら `fix/issue-$ARGUMENTS`）を切る。
+   ```sh
+   git fetch origin && git switch develop && git pull && git switch -c feat/issue-$ARGUMENTS
+   ```
+
+3. **実装**: `swiftui-implementer` サブエージェントに Issue 内容を渡して実装させる。
+
+4. **ビルド検証**: `ios-build-verifier` サブエージェントに Simulator ビルド・起動・スクショ確認をさせる。ビルドが失敗したら error 内容を implementer に戻して修正 → 再検証をループする（最大数回）。
+
+5. **報告**: ユーザーに以下を提示して**ここで止まる**（PR 作成・マージはしない）:
+   - 実装した変更の要約（ファイル一覧）
+   - ビルド/起動の結果とスクリーンショット
+   - 手元で確認してほしい操作
+   - 問題なければ `/ship $ARGUMENTS` で PR 作成に進める旨
+
+コミットは実装が固まった段階で1つにまとめる。commit message 末尾に必ず:
+```
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+push はこの段階では任意（`/ship` 側で行う）。

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,37 @@
+---
+description: 手元確認済みの変更を PR 作成→レビュー→マージする（マージ後は Actions が upload まで自動実行）
+argument-hint: <issue番号>
+allowed-tools: Bash, Read, Grep, Glob, Task
+---
+
+Issue #$ARGUMENTS の変更を PR にしてマージまで進める。**手元での動作確認が済んでいることが前提**。
+
+手順:
+
+1. **事前チェック**: `git status` と `git diff origin/develop...HEAD` で変更内容を確認。未コミットがあればコミットする（message 末尾に `Co-Authored-By: Claude <noreply@anthropic.com>`）。
+
+2. **レビュー**: `swiftui-reviewer` サブエージェントで diff をレビュー。🔴要修正があれば直してから進む。
+
+3. **push & PR 作成**:
+   ```sh
+   git push -u origin HEAD
+   gh pr create --base develop --fill --body "Closes #$ARGUMENTS
+
+   <変更概要 / 手元確認結果 / スクリーンショット言及>
+
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+   ```
+   PR の URL をユーザーに提示する。
+
+4. **CI 確認**: `gh pr checks --watch` で Actions（build 等）の結果を待つ。失敗したら原因を報告して止まる。
+
+5. **マージ確認**: マージは外向きの不可逆操作。**ユーザーに最終承認を得てから**実行する:
+   ```sh
+   gh pr merge --squash --delete-branch
+   ```
+
+6. **マージ後**: `develop` への push で archive/upload の Actions が発火する旨を伝える。TestFlight 外部配信まで行う場合は `ios-release` スキルに従う（ビルド番号採番・外部テスターグループ割り当て）。
+
+注意:
+- `git push`・PR 作成・マージはいずれも外向き操作。push と PR 作成は本コマンドの範囲だが、**マージ前には必ずユーザー確認を挟む**。
+- ベースブランチは常に `develop`。

--- a/.claude/skills/build-run-simulator/SKILL.md
+++ b/.claude/skills/build-run-simulator/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: build-run-simulator
+description: Ninjacord iOS アプリを iOS Simulator でビルド・インストール・起動し、手元で目視確認できる状態にする。ビルドエラーの抽出、Simulator の boot、アプリの install/launch、スクリーンショット取得までを扱う。"Simulator でビルド", "手元で確認", "アプリを起動", "ビルドが通るか" などの要求で参照する。
+---
+
+# build-run-simulator
+
+Ninjacord iOS を Simulator 上で動かして手元確認するための手順。scheme・bundle ID・`.app` パスは**ハードコードせず** `xcodebuild -showBuildSettings` から取得すること（構成変更に強くするため）。
+
+## 前提
+
+- 作業ディレクトリ: リポジトリルート（`NinjacordApp.xcodeproj` がある場所）
+- `.xcodeproj` 直（`-project NinjacordApp.xcodeproj`）
+- Scheme: 開発確認は `NinjacordApp-STG` を優先。本番確認時のみ `NinjacordApp`
+- 依存は SPM。初回は解決に時間がかかる
+
+## 手順
+
+### 1. ターゲット Simulator を選ぶ
+
+利用可能な iPhone を1台選ぶ（起動済みがあればそれを使う）。
+
+```sh
+xcrun simctl list devices available | grep -i iphone
+# 例: "iPhone 17 Pro" を使う
+```
+
+### 2. ビルド
+
+```sh
+SCHEME="NinjacordApp-STG"   # 本番確認なら NinjacordApp
+DEVICE="iPhone 17 Pro"
+
+xcodebuild build \
+  -project NinjacordApp.xcodeproj \
+  -scheme "$SCHEME" \
+  -configuration Debug \
+  -destination "platform=iOS Simulator,name=$DEVICE" \
+  -derivedDataPath ./DerivedData \
+  | tee /tmp/ninjacord-build.log | xcbeautify 2>/dev/null || cat /tmp/ninjacord-build.log
+```
+
+`xcbeautify` が無ければ生ログでよい。**失敗時は `/tmp/ninjacord-build.log` から `error:` 行を抽出**して原因を報告する。
+
+```sh
+grep -n "error:" /tmp/ninjacord-build.log | head -20
+```
+
+### 3. `.app` パスと Bundle ID を取得
+
+```sh
+SETTINGS=$(xcodebuild -showBuildSettings \
+  -project NinjacordApp.xcodeproj -scheme "$SCHEME" -configuration Debug \
+  -destination "platform=iOS Simulator,name=$DEVICE" 2>/dev/null)
+
+BUILT_DIR=$(echo "$SETTINGS" | awk -F' = ' '/ BUILT_PRODUCTS_DIR /{print $2; exit}')
+APP_NAME=$(echo "$SETTINGS" | awk -F' = ' '/ FULL_PRODUCT_NAME /{print $2; exit}')
+BUNDLE_ID=$(echo "$SETTINGS" | awk -F' = ' '/ PRODUCT_BUNDLE_IDENTIFIER /{print $2; exit}')
+APP_PATH="$BUILT_DIR/$APP_NAME"
+echo "APP_PATH=$APP_PATH"; echo "BUNDLE_ID=$BUNDLE_ID"
+```
+
+### 4. Simulator を起動して install / launch
+
+```sh
+xcrun simctl boot "$DEVICE" 2>/dev/null || true
+open -a Simulator
+xcrun simctl install "$DEVICE" "$APP_PATH"
+xcrun simctl launch "$DEVICE" "$BUNDLE_ID"
+```
+
+### 5. スクリーンショットで確認
+
+```sh
+xcrun simctl io "$DEVICE" screenshot /tmp/ninjacord-screen.png
+```
+
+取得した `/tmp/ninjacord-screen.png` を Read して UI を目視確認し、Issue の要件を満たしているか報告する。
+
+## 報告フォーマット
+
+- ビルド: 成功 / 失敗（失敗なら `error:` 行と該当ファイル）
+- 起動: 成功 / 失敗
+- 目視: スクリーンショットを見て、変更点が期待通りか（差分の該当画面に言及）
+
+## 注意
+
+- SPM 解決で固まる場合は `-derivedDataPath ./DerivedData` を消して再試行、または Xcode を一度開いて解決させる。
+- コード署名は Simulator では不要（`CODE_SIGNING_ALLOWED=NO` は付けない — Debug/Simulator は既定で通る）。
+- 破壊的な `simctl erase` は勝手に実行しない。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# Ninjacord iOS
+
+Discord に Webhook / bot 経由でメッセージを送信できる iOS アプリ。
+
+## プロジェクト基本情報
+
+| 項目 | 値 |
+| --- | --- |
+| リポジトリ | `shilokuma-inc/ninjacord-ios` |
+| デフォルトブランチ | `develop` |
+| UI フレームワーク | SwiftUI |
+| 言語 / Xcode | Swift 5 / Xcode 26.3 |
+| Deployment Target | iOS 16.0 |
+| バージョン | `MARKETING_VERSION` 1.5.0 |
+| Bundle ID (本番) | `ml.mrs1669.discord-bot-helper` |
+| App Store | https://apps.apple.com/jp/app/ninja-cord/id6498937487 |
+
+## ビルド構成
+
+- **`.xcodeproj` 直**（`.xcworkspace` は無い）。ビルド対象は常に `-project NinjacordApp.xcodeproj`。
+- Scheme は2つ:
+  - `NinjacordApp` … 本番
+  - `NinjacordApp-STG` … STG（開発確認はこちらを優先）
+- Configuration: `Debug` / `NinjacordApp-STG` / `Release`
+- 依存は全て SPM: Firebase, Alamofire, Google Mobile Ads (AdMob), LicenseList
+- SwiftLint 使用（CI で `brew install swiftlint`）
+
+## ディレクトリ
+
+- `NinjacordApp/` … アプリ本体（SwiftUI View / ViewModel）
+  - `SettingMessage/` … メッセージ送信画面
+  - `Setting/` … 設定・ライセンス・プライバシー
+  - `AdMob/` … 広告
+  - `Extension/`, `Common/` … 共通部品
+- `ci_scripts/ci_post_clone.sh` … CI 前処理（SwiftLint 導入等）
+- `.github/workflows/` … build / archive / upload（`develop`・`master` への push で発火）
+
+## ブランチ運用
+
+- 作業は `develop` 起点でフィーチャーブランチを切る（例: `feat/xxx`, `fix/xxx`）。
+- `develop` / `master` への push で GitHub Actions（build → archive → upload）が発火する。
+- PR のマージ先は原則 `develop`。
+
+## 開発ワークフロー（Claude Code）
+
+1. `/dev-issue <番号>` … Issue を取得 → 実装 → Simulator ビルド&起動 → 手元で確認
+2. 手元確認で問題なければ `/ship <番号>` … PR 作成 → レビュー → マージ
+3. `develop` マージ後は Actions が自動で App Store Connect アップロードまで実施
+
+## コーディング方針
+
+- SwiftUI の作法は `ios-swiftui` スキルに従う（State 管理 / View 分割 / Swift Concurrency）。
+- リリース・署名・TestFlight は `ios-release` スキルを参照する。
+- 変更は最小限、周辺の既存コードのスタイル（命名・コメント密度）に合わせる。


### PR DESCRIPTION
## 概要
Claude Code によるローカル開発ループを整備する初期セットアップ。既存の Swift コードには変更なし（設定ファイルのみ追加）。

## 追加内容
- `CLAUDE.md` — プロジェクトの土台（scheme・`.xcodeproj`直・iOS16・依存・ブランチ運用）
- `.claude/skills/build-run-simulator` — Simulator ビルド→install→launch→スクショの中核手順
- `.claude/agents/` — 実装(swiftui-implementer) / 検証(ios-build-verifier) / レビュー(swiftui-reviewer)
- `.claude/commands/` — `/dev-issue`（実装→手元確認で停止）, `/ship`（レビュー→PR→マージ）

## 使い方
```
/dev-issue <番号>   # 実装してSimulatorで手元確認
/ship <番号>        # レビュー→PR作成→マージ
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)