### PR TITLE
【CHORE】コミット/PR 規約を設定

### DIFF
--- a/.claude/commands/dev-issue.md
+++ b/.claude/commands/dev-issue.md
@@ -25,8 +25,12 @@ Issue #$ARGUMENTS を実装し、Simulator で手元確認できる状態にす�
    - 手元で確認してほしい操作
    - 問題なければ `/ship $ARGUMENTS` で PR 作成に進める旨
 
-コミットは実装が固まった段階で1つにまとめる。commit message 末尾に必ず:
-```
-Co-Authored-By: Claude <noreply@anthropic.com>
-```
+コミット規約（CLAUDE.md「コミット / PR 規約」に従う）:
+- 件名は **`[type] 日本語の説明`**（type は Issue の種別に対応: feat/fix/refactor/chore/update 等）。
+- **粒度を意識する**: 実装を1つの大コミットにまとめず、人間がコミット単位でレビューして意味が追える論理単位に分ける（無関係な変更を混ぜない）。
+- commit message 末尾に必ず:
+  ```
+  Co-Authored-By: Claude <noreply@anthropic.com>
+  ```
+
 push はこの段階では任意（`/ship` 側で行う）。

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -8,16 +8,26 @@ Issue #$ARGUMENTS の変更を PR にしてマージまで進める。**手元�
 
 手順:
 
-1. **事前チェック**: `git status` と `git diff origin/develop...HEAD` で変更内容を確認。未コミットがあればコミットする（message 末尾に `Co-Authored-By: Claude <noreply@anthropic.com>`）。
+1. **事前チェック**: `git status` と `git diff origin/develop...HEAD` で変更内容を確認。未コミットがあれば **`[type] 日本語の説明`** 形式でコミットする（粒度は CLAUDE.md「コミット / PR 規約」に従い論理単位で分ける。message 末尾に `Co-Authored-By: Claude <noreply@anthropic.com>`）。
 
 2. **レビュー**: `swiftui-reviewer` サブエージェントで diff をレビュー。🔴要修正があれば直してから進む。
 
-3. **push & PR 作成**:
+3. **push & PR 作成**: タイトルは **`【TYPE】日本語の説明`**（TYPE は Issue の種別に対応: FEAT/FIX/REFACTOR/CHORE/UPDATE 等）。本文は `.github/pull_request_template.md` の雛形（概要 / 関連するISSUE / 詳細 / 動作確認）に沿って埋める。
    ```sh
    git push -u origin HEAD
-   gh pr create --base develop --fill --body "Closes #$ARGUMENTS
+   gh pr create --base develop --title "【TYPE】<日本語の説明>" --body "## 概要 (Abstract)
+   <何を・なぜ>
 
-   <変更概要 / 手元確認結果 / スクリーンショット言及>
+   ## 関連するISSUE
+   - resolved #$ARGUMENTS
+
+   ## 詳細 (Detail)
+   <主な変更点>
+
+   ## 動作確認 (Verification)
+   - [x] Simulator でビルド・起動を確認した
+   - [x] 想定通りの挙動を目視確認した
+   <UI 変更はスクリーンショットを添付>
 
    🤖 Generated with [Claude Code](https://claude.com/claude-code)"
    ```

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,8 @@
+<!--
+タイトルは 【TYPE】日本語の説明 の形式にしてください（例: 【FEAT】メッセージ送信ボタンを追加）
+TYPE: FEAT / FIX / REFACTOR / CHORE / UPDATE （補助: DOCS / TEST / CI / PERF / STYLE）
+-->
+
 <!-- What's in this pull request? -->
 ## 概要 (Abstract)
 
@@ -8,5 +13,10 @@
 
 ## 詳細 (Detail)
 
+
+## 動作確認 (Verification)
+<!-- UI 変更はスクリーンショットを添付してください -->
+- [ ] Simulator でビルド・起動を確認した
+- [ ] 想定通りの挙動を目視確認した
 
 <!-- Thank you for your contribution! -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,37 @@ Discord に Webhook / bot 経由でメッセージを送信できる iOS アプ�
 2. 手元確認で問題なければ `/ship <番号>` … PR 作成 → レビュー → マージ
 3. `develop` マージ後は Actions が自動で App Store Connect アップロードまで実施
 
+## コミット / PR 規約
+
+人間・Claude いずれの手作業でも本規約に従うこと。
+
+### type 一覧
+
+既存の Issue テンプレート（`.github/ISSUE_TEMPLATE/`）の分類に揃える。基本はこの5種。
+
+| type | 用途 | 対応 Issue タイトル |
+| --- | --- | --- |
+| `feat` | 新機能・機能追加 | 【FEAT】 |
+| `fix` | バグ修正 | 【FIX】 |
+| `refactor` | 挙動を変えない内部改善 | 【REFACTOR】 |
+| `chore` | 雑務（依存更新・設定・CI 等） | 【CHORE】 |
+| `update` | バージョンアップ | 【UPDATE】 |
+
+補助的に `docs` / `test` / `ci` / `perf` / `style` を使ってもよい（明確に該当する場合のみ）。
+
+### コミットメッセージ
+
+- 件名: **`[type] 日本語の説明`**（type は半角小文字。例: `[feat] メッセージ送信ボタンを追加`）
+- 説明は「何をしたか」を簡潔に。必要なら空行の後に本文で「なぜ」を書く。
+- **粒度**: 1コミット＝1つの論理的変更。人間がコミット単位でレビューして意味が追える単位に分け、無関係な変更を同じコミットに混ぜない（例: 「機能追加」と「既存のリネーム」は別コミット）。
+- Claude が作成したコミットは末尾に `Co-Authored-By: Claude <noreply@anthropic.com>` を付ける。
+
+### PR タイトル
+
+- **`【TYPE】日本語の説明`**（`【】` は全角、TYPE は半角大文字。例: `【FEAT】メッセージ送信ボタンを追加`）
+- TYPE はコミット type を大文字化したもの。原則、対応する Issue のタイトル（【FEAT】等）と同じ種別にする。
+- PR 本文は `.github/pull_request_template.md` の雛形に従う。
+
 ## コーディング方針
 
 - SwiftUI の作法は `ios-swiftui` スキルに従う（State 管理 / View 分割 / Swift Concurrency）。


### PR DESCRIPTION
## 概要 (Abstract)
コミットメッセージと PR タイトルの命名規約を整備する。人間・Claude いずれの作業にも適用する。

## 関連するISSUE
- resolved #

## 詳細 (Detail)
- `CLAUDE.md` に「コミット / PR 規約」を追加
  - コミット件名: `[type] 日本語の説明`（半角小文字 prefix）
  - PR タイトル: `【TYPE】日本語の説明`（全角【】+ 半角大文字）
  - type は既存 Issue テンプレートに合わせ feat/fix/refactor/chore/update を基本とする
  - コミット粒度: 人間がコミット単位でレビューできる論理単位に分ける
- `.github/pull_request_template.md` にタイトル形式の注記と動作確認チェックリストを追加（既存項目は維持）
- `/dev-issue`・`/ship` コマンドを上記規約に追従

## 動作確認 (Verification)
- [x] 本PR自体を新規約（`【CHORE】`タイトル・[chore] コミット・2コミット分割）で作成し、フォーマットを実地確認
- [ ] Simulator ビルド: 本PRは設定/ドキュメントのみのため対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)