### PR TITLE
【UPDATE】MARKETING_VERSION を 1.5.1 に更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Discord に Webhook / bot 経由でメッセージを送信できる iOS アプ�
 | UI フレームワーク | SwiftUI |
 | 言語 / Xcode | Swift 5 / Xcode 26.3 |
 | Deployment Target | iOS 16.0 |
-| バージョン | `MARKETING_VERSION` 1.5.0 |
+| バージョン | `MARKETING_VERSION` 1.5.1 |
 | Bundle ID (本番) | `ml.mrs1669.discord-bot-helper` |
 | App Store | https://apps.apple.com/jp/app/ninja-cord/id6498937487 |
 

--- a/NinjacordApp.xcodeproj/project.pbxproj
+++ b/NinjacordApp.xcodeproj/project.pbxproj
@@ -502,7 +502,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.2;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "ml.mrs1669.discord-bot-helper";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -549,7 +549,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.2;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "ml.mrs1669.discord-bot-helper";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -657,7 +657,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.2;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "ml.mrs1669.discord-bot-helper";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;


### PR DESCRIPTION
## 概要 (Abstract)

`develop` への push で発火する **Upload/develop** ワークフローが、App Store Connect へのアップロード時に失敗していた問題を修正する。

## 関連するISSUE
- resolved #

## 詳細 (Detail)

直近の Upload/develop（[run 29143447753](https://github.com/shilokuma-inc/ninjacord-ios/actions/runs/29143447753)）が `altool` のアップロードで以下のエラーにより失敗していた:

- `CFBundleShortVersionString [1.5.0] must contain a higher version than the previously approved version [1.5.0]` (90062)
- `Invalid Pre-Release Train. The train version '1.5.0' is closed for new build submissions` (90186)

`1.5.0` は既に App Store Connect で承認済みでビルド提出が閉じているため、同一バージョンのビルドを受け付けられない状態だった。ワークフロー定義自体に不具合はなく、バージョン番号のバンプで解消する。

- `NinjacordApp.xcodeproj/project.pbxproj` の全構成（Debug / STG / Release）の `MARKETING_VERSION` を `1.5.0` → `1.5.1`
- `CLAUDE.md` のバージョン記載も追従

## 動作確認 (Verification)
<!-- UI 変更なし。CI（Upload/develop）での検証となる -->
- [ ] Simulator でビルド・起動を確認した（本変更はバージョン番号のみで挙動変化なし）
- [x] `develop` マージ後の Upload/develop Actions がアップロード成功することで検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)